### PR TITLE
Restructure show completed

### DIFF
--- a/lib/ideas.js
+++ b/lib/ideas.js
@@ -47,6 +47,14 @@ class Ideas {
     return this.all.filter(e => (e).quality === "none")
   }
 
+  findCompletedIdeas(completed){
+    return this.all.filter(e => e.completed === true)
+  }
+
+  findIncompleteIdeas(completed){
+    return this.all.filter(e => e.completed === false)
+  }
+
 }
 
 module.exports = Ideas

--- a/lib/scripts.js
+++ b/lib/scripts.js
@@ -37,8 +37,11 @@ $('#all-ideas').on('click', (e) => {
 })
 
 const renderCompletedIdeas = () => {
-  const renderArray = ideaArray.filter(e => e.completed === true)
-  renderArray.forEach((e) => {
+  helpers.emptyIdeas()
+  ideas.findIncompleteIdeas().forEach((e) => {
+    $('ideas').prepend(createCard(e))
+  })
+  ideas.findCompletedIdeas().forEach((e) => {
     $('ideas').prepend(createCard(e))
   })
 }


### PR DESCRIPTION
Show completed now empties out the idea section.  The arrays of completed and uncompleted ideas  are now in the ideas class.  First we prepend uncompleted, then completed.  This solves the display issue with a slight refactor.  